### PR TITLE
Add Dockerfile, entrypoint and openshift template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY ./src/ .
 COPY ./Pipfile Pipfile
 COPY ./Pipfile.lock Pipfile.lock
 COPY ./entrypoint.sh entrypoint.sh
+COPY ./gunicorn.conf.py gunicorn.conf.py
 
 # Set the Pythonpath to the sources root.
 ENV PYTHONPATH="/opt/app-root/"\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# UBI with Python 3.8 version, see base Dockerfile here:
+# https://catalog.redhat.com/software/containers/ubi8/python-38/5dde9cacbed8bd164a0af24a?gti-tabs=unauthenticated&container-tabs=dockerfile
+FROM registry.access.redhat.com/ubi8/python-38:latest
+
+LABEL MAINTAINER "Avishkar Gupta <avgupta@redhat.com>"
+
+EXPOSE 6006
+
+# Upgrade dependency management itself.
+RUN pip install --upgrade pip pipenv
+
+# Copy the sources to the app root, see base image Dockerfile for more details.
+WORKDIR /opt/app-root/src/
+
+COPY ./src/ .
+
+# Copy the locked env since this is a production build.
+COPY ./Pipfile Pipfile
+COPY ./Pipfile.lock Pipfile.lock
+COPY ./entrypoint.sh entrypoint.sh
+
+# Set the Pythonpath to the sources root.
+ENV PYTHONPATH="/opt/app-root/"\
+    PIPENV_HIDE_EMOJIS="true" \
+    VIRTUAL_ENV="/opt/app-root/"
+
+# Install application dependencies.
+RUN pipenv install --deploy --ignore-pipfile
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ $ pycodestyle .
 $ pydocstyle .
 ```
 
-## Databse connection
+## Database connection
 
-The databse connection is managed by `flask-sqlalchemy`, you need to setup the environment variables (either through Openshift Secrets/template/configmaps) or otherwise to set the proper values in the the `_POSTGRES_CONFIG` in the [config](/src/config.py). The env-vars are:
+The database connection is managed by `flask-sqlalchemy`, you need to setup the environment variables (either through Openshift Secrets/template/configmaps) or otherwise to set the proper values in the the `_POSTGRES_CONFIG` in the [config](/src/config.py). The env-vars are:
 
  - PG_HOST
  - PG_DATABASE

--- a/README.md
+++ b/README.md
@@ -53,6 +53,55 @@ The databse connection is managed by `flask-sqlalchemy`, you need to setup the e
  - PG_PASSWORD
  - PG_USERNAME
 
+
+## Setting up the service on Openshift
+
+The code first needs to be pacakged into a container using the [Dockerfile](/Dockerfile) available in this repository and you need to update the corresponding properties:
+
+- IMAGE_TAG
+- DOCKER_IMAGE
+- DOCKER_REGISTRY
+
+fields in the [openshift template](./openshift/template.yaml) that is present in the repository.
+
+This repository requires one configmap and one secret to work with:
+
+### configmap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telanlyt-config
+data:
+  pg_host: # value goes here
+  pg_username: # value goes here
+  pg_database_workload_api: # value goes here 
+```
+
+### secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: telanlyt-secrets
+type: Opaque
+data:
+  pg_password: # base64 encoded value goes here.
+  secret_token_generation: # base64 encoded value goes here.
+  secret_client_api_token: # base64 encoded value goes here.
+```
+
+After applying the secret and the configmap in the desired namespace, the template can be used to create resources in the namespace as with:
+
+```bash
+$ oc login ${YOUR_CLUSTER_URL}
+$ oc project ${YOUR_NAMESPACE}
+$ oc process -f openshift/template.yaml | oc create -f -
+```
+
+The template contains a `route` definition, a `service` definition and a `deploymentConfig`, the corresponding route that is generated can be retrieved with the output of `oc get routes`.
 ## License
 Copyright 2021 Red Hat Inc.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ kind: ConfigMap
 metadata:
   name: telanlyt-config
 data:
-  pg_host: # value goes here
-  pg_username: # value goes here
-  pg_database_workload_api: # value goes here 
+  PG_HOST: # value goes here.
+  PG_USERNAME: # value goes here.
+  PG_DATABASE: # value goes here.
 ```
 
 ### secret
@@ -88,9 +88,9 @@ metadata:
   name: telanlyt-secrets
 type: Opaque
 data:
-  pg_password: # base64 encoded value goes here.
-  secret_token_generation: # base64 encoded value goes here.
-  secret_client_api_token: # base64 encoded value goes here.
+  PG_PASSWORD: # base64 encoded value goes here.
+  SECRET_TOKEN_GENERATION: # base64 encoded value goes here.
+  SECRET_CLIENT_API_TOKEN: # base64 encoded value goes here.
 ```
 
 After applying the secret and the configmap in the desired namespace, the template can be used to create resources in the namespace as with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-gunicorn -b 0.0.0.0:${API_SERVER_PORT} --workers=${NUMBER_WORKER_PROCESS} -k ${WORKER_TYPE} -t ${API_SERVER_TIMEOUT} src.server:app
+
+# Our pythonpath and workdir are set through the dockerfile itself.
+# Don't set one here that is different, change that if required.
+gunicorn -c gunicorn.conf.py src.server:app

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+gunicorn -b 0.0.0.0:${API_SERVER_PORT} --workers=${NUMBER_WORKER_PROCESS} -k ${WORKER_TYPE} -t ${API_SERVER_TIMEOUT} src.server:app

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,18 @@
+"""The gunicorn config for wherever it's used to serve."""
+import os
+
+from gevent import monkey
+
+# Boilerplate to patch our app.
+monkey.patch_all()
+
+_port = os.environ.get("API_SERVER_PORT", 6006)
+
+bind: str = f"0.0.0.0:{_port}"
+workers: int = os.environ.get("NUMBER_WORKER_PROCESS", 4)
+worker_class: str = os.environ.get("WORKER_TYPE", "gevent")
+
+timeout: int = os.environ.get("API_SERVER_TIMEOUT", 90)
+accesslog: str = "-"  # Since everything logged to stdout goes to Kibana this is fixed forever.
+errorlog: str = "-"  # Same reason as above.
+preload: bool = True  # I see no reason to turn this off because gunicorn shouldn't be used locally as a dev server.

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -56,14 +56,13 @@ objects:
                 failureThreshold: 3
                 successThreshold: 1
               readinessProbe:
-                # TODO: Set this to the real readiness check once
-                # DB connection kinks are worked out.
-                tcpSocket:
+                httpGet:
+                  path: /api/v1/readiness
                   port: ${{API_SERVER_PORT}}
                 failureThreshold: 3
                 successThreshold: 1
-                initialDelaySeconds: 20
-                periodSeconds: 60
+                initialDelaySeconds: 60
+                periodSeconds: 60 # check whether DB is live once every minute.
                 timeoutSeconds: 30
               resources:
                 requests:
@@ -167,7 +166,7 @@ parameters:
     name: WORKER_TYPE
     value: "gevent"
 
-  - description: Connection pool size
+  - description: Connection pool size for each gevent worker
     displayName: Worker Pool Size
     required: true
     name: WORKER_CONNECTION_POOL_LIMIT

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -64,6 +64,8 @@ objects:
                   value: ${NUMBER_WORKER_PROCESS}
                 - name: WORKER_TYPE
                   value: ${WORKER_TYPE}
+                - name: WORKER_CONNECTION_POOL_LIMIT
+                  value: ${WORKER_CONNECTION_POOL_LIMIT}
 
               image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
               name: telanlyt-api
@@ -188,4 +190,10 @@ parameters:
     displayName: Worker type
     required: true
     name: WORKER_TYPE
-    value: "sync"
+    value: "gevent"
+
+  - description: Connection pool size
+    displayName: Worker Pool Size
+    required: true
+    name: WORKER_CONNECTION_POOL_LIMIT
+    value: "1024"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -165,7 +165,7 @@ parameters:
     displayName: Number of deployment replicas
     required: true
     name: REPLICAS
-    value: "1"
+    value: "3"
 
   - description: Port Number
     displayName: Port Number
@@ -176,7 +176,7 @@ parameters:
   - description: The application gateway timeout for the apiserver for each request
     displayName: API Server Timeout
     name: API_SERVER_TIMEOUT
-    value: "900"
+    value: "90"
 
   - description: Number of gunicorn worker processes
     displayName: Number of worker processes

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: telanlyt-api
+metadata:
+  name: telanlyt-api
+  annotations:
+    description: A template that contains the deploymentconfig for telemetry analytics API server deployment.
+objects:
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        service: telanlyt-api
+      name: telanlyt-api
+    spec:
+      replicas: "${{REPLICAS}}"
+      selector:
+        service: telanlyt-api
+      template:
+        metadata:
+          labels:
+            service: telanlyt-api
+        spec:
+          containers:
+            - command:
+                - ./entrypoint.sh
+              env:
+                - name: PG_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      name: telanlyt-config
+                      key: pg_host
+                - name: PG_USERNAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: telanlyt-config
+                      key: pg_username
+                - name: PG_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: telanlyt-secrets
+                      key: pg_password
+                - name: PG_DATABASE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: telanlyt-config
+                      key: pg_database_workload_api
+                - name: SECRET_CLIENT_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: telanlyt-secrets
+                      key: secret_client_api_token
+                - name: SECRET_TOKEN_GENERATION
+                  valueFrom:
+                    secretKeyRef:
+                      name: telanlyt-secrets
+                      key: secret_token_generation
+                - name: API_SERVER_PORT
+                  value: ${API_SERVER_PORT}
+                - name: API_SERVER_TIMEOUT
+                  value: ${API_SERVER_TIMEOUT}
+                - name: NUMBER_WORKER_PROCESS
+                  value: ${NUMBER_WORKER_PROCESS}
+                - name: WORKER_TYPE
+                  value: ${WORKER_TYPE}
+
+              image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
+              name: telanlyt-api
+              ports:
+                - containerPort: ${{API_SERVER_PORT}}
+              livenessProbe:
+                httpGet:
+                  path: /api/v1/
+                  port: ${{API_SERVER_PORT}}
+                initialDelaySeconds: 60
+                periodSeconds: 60
+                timeoutSeconds: 30
+                failureThreshold: 3
+                successThreshold: 1
+              readinessProbe:
+                # TODO: Set this to the real readiness check once
+                # DB connection kinks are worked out.
+                tcpSocket:
+                  port: ${{API_SERVER_PORT}}
+                failureThreshold: 3
+                successThreshold: 1
+                initialDelaySeconds: 20
+                periodSeconds: 60
+                timeoutSeconds: 30
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        service: telanlyt-api
+      name: telanlyt-api
+    spec:
+      ports:
+        - port: ${{API_SERVER_PORT}}
+          name: "${API_SERVER_PORT}"
+          targetPort: ${{API_SERVER_PORT}}
+          protocol: TCP
+      selector:
+        service: telanlyt-api
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      name: telanlyt-api
+    spec:
+      to:
+        kind: Service
+        name: telanlyt-api
+
+parameters:
+  - description: CPU request
+    displayName: CPU request
+    required: true
+    name: CPU_REQUEST
+    value: "128m"
+
+  - description: CPU limit
+    displayName: CPU limit
+    required: true
+    name: CPU_LIMIT
+    value: "500m"
+
+  - description: Memory request
+    displayName: Memory request
+    required: true
+    name: MEMORY_REQUEST
+    value: "256Mi"
+
+  - description: Memory limit
+    displayName: Memory limit
+    required: true
+    name: MEMORY_LIMIT
+    value: "1Gi"
+
+  - description: Docker registry where the image is
+    displayName: Docker registry
+    required: true
+    name: DOCKER_REGISTRY
+    value: "quay.io"
+
+  - description: Docker image to use
+    displayName: Docker image
+    required: true
+    name: DOCKER_IMAGE
+    value: "rootavish/telanlyt-api"
+
+  - description: Image tag
+    displayName: Image tag
+    required: true
+    name: IMAGE_TAG
+    value: "latest"
+
+  - description: Number of deployment replicas
+    displayName: Number of deployment replicas
+    required: true
+    name: REPLICAS
+    value: "1"
+
+  - description: Port Number
+    displayName: Port Number
+    required: true
+    name: API_SERVER_PORT
+    value: "6006"
+
+  - description: The application gateway timeout for the apiserver for each request
+    displayName: API Server Timeout
+    name: API_SERVER_TIMEOUT
+    value: "900"
+
+  - description: Number of gunicorn worker processes
+    displayName: Number of worker processes
+    required: true
+    name: NUMBER_WORKER_PROCESS
+    value: "4"
+
+  - description: Type of gunicorn worker (sync/async)
+    displayName: Worker type
+    required: true
+    name: WORKER_TYPE
+    value: "sync"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -25,37 +25,12 @@ objects:
           containers:
             - command:
                 - ./entrypoint.sh
+              envFrom:
+                - configMapRef:
+                    name: telanlyt-config
+                - secretRef:
+                    name: telanlyt-secrets
               env:
-                - name: PG_HOST
-                  valueFrom:
-                    configMapKeyRef:
-                      name: telanlyt-config
-                      key: pg_host
-                - name: PG_USERNAME
-                  valueFrom:
-                    configMapKeyRef:
-                      name: telanlyt-config
-                      key: pg_username
-                - name: PG_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: telanlyt-secrets
-                      key: pg_password
-                - name: PG_DATABASE
-                  valueFrom:
-                    configMapKeyRef:
-                      name: telanlyt-config
-                      key: pg_database_workload_api
-                - name: SECRET_CLIENT_API_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: telanlyt-secrets
-                      key: secret_client_api_token
-                - name: SECRET_TOKEN_GENERATION
-                  valueFrom:
-                    secretKeyRef:
-                      name: telanlyt-secrets
-                      key: secret_token_generation
                 - name: API_SERVER_PORT
                   value: ${API_SERVER_PORT}
                 - name: API_SERVER_TIMEOUT

--- a/src/api-spec/workload-api-spec.yaml
+++ b/src/api-spec/workload-api-spec.yaml
@@ -239,7 +239,7 @@ components:
           - 549068
           - 645908
           - 29876582
-        offset: 100
+        offset: 0
         record_count: 50
     accountsResponseExample:
       value:

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ _POSTGRES_CONFIG = {
     "USERNAME": os.environ.get("PG_USERNAME"),
 }
 
-app = connexion.App(__name__, specification_dir="api-spec/", server="gevent")
+app = connexion.App(__name__, specification_dir="api-spec/")
 
 flask_app = app.app
 


### PR DESCRIPTION
I have tested it on the cluster we have. It comes up and you can access the swagger UI but the database connection isn't there yet and hence I've not put in a readiness check for now, data retrieval fails there too for now.

I've mentioned in the README how it's supposed to be setup and the configmap and secret definitions as well but without the values (since I couldn't add the real ones here for obvious reasons).

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>